### PR TITLE
fix(Dependencies): 🐛 Update rand versions to current 0.8.4

### DIFF
--- a/.whitesource
+++ b/.whitesource
@@ -1,0 +1,13 @@
+{
+  "scanSettings": {
+    "baseBranches": []
+  },
+  "checkRunSettings": {
+    "vulnerableCheckRunConclusionLevel": "failure",
+    "displayMode": "diff"
+  },
+  "issueSettings": {
+    "minSeverityLevel": "LOW",
+    "issueType": "DEPENDENCY"
+  }
+}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ name = "fakeit"
 harness = false
 
 [dependencies]
-rand = "0.6.5"
+rand = "0.8.4"
 libmath = "0.2.1"
 chrono = "0.4"
 uuid = { version = "0.8", features = ["v1", "v4"] }


### PR DESCRIPTION
@PumpkinSeed for your consideration:

### [CVE-2020-25576](https://github.com/advisories/GHSA-mmc9-pwm7-qj5w) - High Severity Vulnerability
Vulnerable Library - rand_core-0.3.1.crate

Core random number generator traits and tools for implementation.

Library home page: https://crates.io/api/v1/crates/rand_core/0.3.1/download

#### Before Update: 
rand v0.6.5
├── libc v0.2.116
├── rand_chacha v0.1.1
│   └── rand_core v0.3.1
│       └── rand_core v0.4.2
│   [build-dependencies]
│   └── autocfg v0.1.7
├── rand_core v0.4.2
├── rand_hc v0.1.0
│   └── rand_core v0.3.1 (*) ❌ (Vulnerable Library)
├── rand_isaac v0.1.1
│   └── rand_core v0.3.1 (*) ❌ (Vulnerable Library)
├── rand_jitter v0.1.4
│   └── rand_core v0.4.2
├── rand_os v0.1.3
│   ├── libc v0.2.116
│   └── rand_core v0.4.2
├── rand_pcg v0.1.2
│   └── rand_core v0.4.2
│   [build-dependencies]
│   └── autocfg v0.1.7
└── rand_xorshift v0.1.1
    └── rand_core v0.3.1 (*) ❌ (Vulnerable Library)

#### After Update:
rand v0.8.4
├── libc v0.2.116
├── rand_chacha v0.3.1
│   ├── ppv-lite86 v0.2.16
│   └── rand_core v0.6.3
│       └── getrandom v0.2.4
│           ├── cfg-if v1.0.0
│           └── libc v0.2.116
└── rand_core v0.6.3 (*)
