### PR TITLE
Fix RUSTSEC-2020-0071

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,6 @@ harness = false
 [dependencies]
 rand = "0.6.5"
 libmath = "0.2.1"
-chrono = "0.4"
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
 uuid = { version = "0.8", features = ["v1", "v4"] }
 simplerand = "1.2.0"

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -70,7 +70,9 @@ pub fn date_range(min: String, max: String) -> DateTime<Utc> {
         nsecs = 1_999_999_999;
     }
 
-    DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(secs, nsecs as u32), Utc)
+    let datetime = NaiveDateTime::from_timestamp_opt(secs, nsecs as u32)
+        .expect("invalid or out-of-range datetime");
+    DateTime::<Utc>::from_utc(datetime, Utc)
 }
 
 pub fn date() -> DateTime<Utc> {


### PR DESCRIPTION
https://rustsec.org/advisories/RUSTSEC-2020-0071

Although this crate doesn't use any of the affected methods on the
advisory, it transiftively uses the version of the crate with the issue.
This caused cargo deny check to be triggered when adding this to a repo
for testing.

The change in datetime.rs fixes the call to a deprecated method in
chrono. It's also unlikely to be triggered, but fixed for good measure.
