### PR TITLE
Bump rand dependency to fix RUSTSEC-2025-0124

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ name = "fakeit"
 harness = false
 
 [dependencies]
-rand = "0.6.5"
+rand = "0.9.2"
 libmath = "0.2.1"
 uuid = { version = "0.8", features = ["v1", "v4"] }
 simplerand = "1.2.0"


### PR DESCRIPTION
See <https://rustsec.org/advisories/RUSTSEC-2025-0124>

This also affects @ratatui here: <https://github.com/ratatui/ratatui/issues/2215>

It would be nice to cut a new release after this! 👼
